### PR TITLE
Add cors headers

### DIFF
--- a/api/go/routers.go
+++ b/api/go/routers.go
@@ -63,6 +63,7 @@ func NewRouter(routers ...Router) *mux.Router {
 // EncodeJSONResponse uses the json encoder to write an interface to the http response with an optional status code
 func EncodeJSONResponse(i interface{}, status *int, w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	if status != nil {
 		w.WriteHeader(*status)
 	} else {


### PR DESCRIPTION
Make cors header public to make this a public API.

This will apply the cors header to any api that returns a json response (which is all of them). Tested by running it locally.

Maybe we should lock down the header to the github pages url and localhost? We'll probably want to set an environment variable for prod vs dev so that the headers switch from github pages and localhost respectively.

Not sure how to do that with go yet.